### PR TITLE
Pin configstore to last "non-ESM" version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "homeautomation-js-lib": "https://github.com/terafin/homeautomation-js-lib.git",
         "lodash": "latest",
-        "configstore": "latest",
+        "configstore": "3.1.5",
         "reconnecting-websocket": "4.4.0",
         "moment-timezone": "latest",
         "ws": "latest",


### PR DESCRIPTION
I'm not a JS person, but this fixes
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /usr/node_app/node_modules/configstore/index.js from /usr/node_app/index.js not supported.
```
seen with the current version. I'm sure there is a better way of fixing this, but for the moment...

Fixes #90.