### PR TITLE
Prevent crash on null values in messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -340,7 +340,9 @@ const cleanupCollection = function(collection) {
         }
 
 
-        fixed[key] = value.toString()
+        if (value !== null) {
+                fixed[key] = value.toString()
+        }
     })
 
     return fixed


### PR DESCRIPTION
This prevents on a crash on my zigbee cluster when using remote controls, I haven't fully investigated, but seems like a reasonable protective measure.