### PR TITLE
Shallow copy mqtt options object when modifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -449,7 +449,7 @@ const handleUpdateEvent = function(query, json) {
 
     if (!_.isNil(state)) {
         if (!_.isNil(state.buttonevent) && !query) {
-            var newOptions = mqttOptions
+            var newOptions = {... mqttOptions}
             newOptions.retain = false
             client.publish(mqtt_helpers.generateTopic(topicPrefix, 'buttonevent'), state.buttonevent, newOptions)
         }


### PR DESCRIPTION
Objects in js are passed by reference, make a shallow copy of mqttOptions object when clearing retain flag for generated button events. Fixes #93.